### PR TITLE
Deleted Spring boot test config with a test Repository config It. Red…

### DIFF
--- a/persistence/src/test/java/com/taxy4fun/repository/DriverRepositoryTest.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/DriverRepositoryTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 /**
  * Created by mvillafuertem on 9/1/17.
  */
-@SpringBootTest(classes = RepositoryConfig.class)
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public class DriverRepositoryTest {

--- a/persistence/src/test/java/com/taxy4fun/repository/JourneyRepositoryTest.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/JourneyRepositoryTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mvillafuertem on 9/6/17.
  */
-@SpringBootTest(classes = RepositoryConfig.class)
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public class JourneyRepositoryTest {

--- a/persistence/src/test/java/com/taxy4fun/repository/PersonRepositoryTest.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/PersonRepositoryTest.java
@@ -15,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by cmartin on 23/06/2017.
  */
-@SpringBootTest(classes = RepositoryConfig.class)
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public class PersonRepositoryTest {

--- a/persistence/src/test/java/com/taxy4fun/repository/RouteRepositoryTest.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/RouteRepositoryTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mvillafuertem on 9/5/17.
  */
-@SpringBootTest(classes = RepositoryConfig.class)
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public class RouteRepositoryTest {

--- a/persistence/src/test/java/com/taxy4fun/repository/TestRepositoryConfigIT.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/TestRepositoryConfigIT.java
@@ -1,0 +1,15 @@
+package com.taxy4fun.repository;
+
+/*
+Indicates that a class provides Spring Boot application @Configuration. Can be used as an alternative to the Spring's standard @Configuration annotation so that configuration can be found automatically (for example in tests).
+Application should only ever include one @SpringApplicationConfiguration and most idiomatic Spring Boot applications will inherit it from @SpringBootApplication.
+*/
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Import;
+
+@SpringBootConfiguration
+@Import({RepositoryConfig.class})
+//use to test our class with Spring boot  autoconfig
+public class TestRepositoryConfigIT {
+}

--- a/persistence/src/test/java/com/taxy4fun/repository/VehicleRepositoryTest.java
+++ b/persistence/src/test/java/com/taxy4fun/repository/VehicleRepositoryTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mvillafuertem on 8/29/17.
  */
-@SpringBootTest(classes = RepositoryConfig.class)
 @DataJpaTest
 @RunWith(SpringRunner.class)
 public class VehicleRepositoryTest {


### PR DESCRIPTION
When testing Spring Boot applications this is often not required. Spring Boot’s @*Test annotations will search for your primary configuration automaticallywhenever you don’t explicitly define one. The search algorithm works up from the package that contains the test until it finds a @SpringBootApplication or @SpringBootConfiguration annotated class.
 As long as you’ve structured your code in a sensible way your main configuration is usually found.